### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,14 +13,14 @@
           "runs-on": "ubuntu-latest",
           steps:
             [
-              { name: "Check out code", uses: "actions/checkout@v4" },
+              { name: "Check out code", uses: "actions/checkout@v6" },
               {
                 name: "Set up pnpm",
-                uses: "pnpm/action-setup@v4",
+                uses: "pnpm/action-setup@v5",
               },
               {
                 name: "Set up Node.js",
-                uses: "actions/setup-node@v4",
+                uses: "actions/setup-node@v6",
                 with: { "node-version": "22", cache: "pnpm" },
               },
               {
@@ -39,7 +39,7 @@
           "runs-on": "ubuntu-latest",
           steps:
             [
-              { name: "Check out code", uses: "actions/checkout@v4" },
+              { name: "Check out code", uses: "actions/checkout@v6" },
               {
                 name: "Set up Docker Buildx",
                 uses: "docker/setup-buildx-action@v3",


### PR DESCRIPTION
## Summary
This PR updates the GitHub Actions used in the CI/CD workflow to their latest major versions to ensure compatibility, security, and access to the latest features.

## Key Changes
- Upgraded `actions/checkout` from v4 to v6
- Upgraded `pnpm/action-setup` from v4 to v5
- Upgraded `actions/setup-node` from v4 to v6

## Details
These upgrades are applied consistently across both the build and Docker build workflow jobs. The updates ensure the workflow uses the latest stable versions of these critical GitHub Actions, which may include performance improvements, bug fixes, and enhanced compatibility with Node.js 22 and pnpm.

https://claude.ai/code/session_01TBJPAGKRbVSACoEE5PG6bX