### PR TITLE
Add discussion links for Hacker News and Bluesky to posts

### DIFF
--- a/content/posts/2026-05-01-cloudwatch-insights-tool.md
+++ b/content/posts/2026-05-01-cloudwatch-insights-tool.md
@@ -2,6 +2,8 @@
 layout: post
 title: "Small tools, shared with agents: a CloudWatch Insights example"
 date: 2026-05-01
+bluesky: "https://bsky.app/profile/skagedal.tech/post/3mkrwhicma22d"
+hackernews: "https://news.ycombinator.com/item?id=47973166"
 summary: "On building small CLI tools for myself – and now for my agents too. Walks through a recent one for querying CloudWatch Insights, and how I use Claude to analyze the logs it pulls down."
 ---
 

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -97,7 +97,13 @@ export default async function PostPage({
           </header>
           {post.draft && <DraftCard />}
           <MarkdownPost content={post.content} />
-          {showComments && <Comments pageId={slug} />}
+          {showComments && (
+            <Comments
+              pageId={slug}
+              hackernews={post.hackernews}
+              bluesky={post.bluesky}
+            />
+          )}
         </article>
       </main>
       <Footer previous={post.previous} next={post.next} />

--- a/src/components/comments/comments.tsx
+++ b/src/components/comments/comments.tsx
@@ -3,14 +3,17 @@ import { FormOrLogin } from "./comment-form";
 import { ClientContext } from "./client-context";
 import { getUser } from "@/lib/user";
 import { CommentsList } from "./comments-list";
+import { DiscussLinks } from "./discuss-links";
 
 export const dynamic = "force-dynamic";
 
 type Props = {
   pageId: string;
+  hackernews?: string;
+  bluesky?: string;
 }
 
-export async function Comments({ pageId }: Props) {
+export async function Comments({ pageId, hackernews, bluesky }: Props) {
   const user = await getUser();
   console.log('User:', user);
 
@@ -20,6 +23,7 @@ export async function Comments({ pageId }: Props) {
         <MessageSquare className="mr-2 h-5 w-5" />
         Comments
       </h2>
+      <DiscussLinks hackernews={hackernews} bluesky={bluesky} />
       <ClientContext>
         <FormOrLogin pageId={pageId} user={user} />
         <CommentsList pageId={pageId} />

--- a/src/components/comments/discuss-links.tsx
+++ b/src/components/comments/discuss-links.tsx
@@ -1,0 +1,38 @@
+type Props = {
+  hackernews?: string;
+  bluesky?: string;
+};
+
+export function DiscussLinks({ hackernews, bluesky }: Props) {
+  if (!hackernews && !bluesky) {
+    return null;
+  }
+
+  const links: React.ReactNode[] = [];
+  if (hackernews) {
+    links.push(
+      <a key="hn" href={hackernews} className="underline">
+        Hacker News
+      </a>
+    );
+  }
+  if (bluesky) {
+    links.push(
+      <a key="bsky" href={bluesky} className="underline">
+        Blue Sky
+      </a>
+    );
+  }
+
+  const joined: React.ReactNode[] = [];
+  links.forEach((link, i) => {
+    if (i > 0) joined.push(<span key={`sep-${i}`}> or </span>);
+    joined.push(link);
+  });
+
+  return (
+    <p className="mb-6 text-muted-foreground">
+      Discuss this post on {joined}.
+    </p>
+  );
+}

--- a/src/components/comments/discuss-links.tsx
+++ b/src/components/comments/discuss-links.tsx
@@ -1,3 +1,5 @@
+import { Anchor } from "@/components/ui/typography";
+
 type Props = {
   hackernews?: string;
   bluesky?: string;
@@ -11,16 +13,16 @@ export function DiscussLinks({ hackernews, bluesky }: Props) {
   const links: React.ReactNode[] = [];
   if (hackernews) {
     links.push(
-      <a key="hn" href={hackernews} className="underline">
+      <Anchor key="hn" href={hackernews}>
         Hacker News
-      </a>
+      </Anchor>
     );
   }
   if (bluesky) {
     links.push(
-      <a key="bsky" href={bluesky} className="underline">
+      <Anchor key="bsky" href={bluesky}>
         Blue Sky
-      </a>
+      </Anchor>
     );
   }
 
@@ -32,7 +34,7 @@ export function DiscussLinks({ hackernews, bluesky }: Props) {
 
   return (
     <p className="mb-6 text-muted-foreground">
-      Discuss this post on {joined}.
+      Or discuss this post on {joined}.
     </p>
   );
 }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -13,6 +13,8 @@ const Front = z.object({
   tags: z.array(z.string()).optional(),
   summary: z.string().optional(),
   ogImage: z.string().optional(),
+  hackernews: z.string().url().optional(),
+  bluesky: z.string().url().optional(),
 });
 
 export type Post = {
@@ -23,6 +25,8 @@ export type Post = {
   slug: string;
   tags?: string[];
   ogImage?: string;
+  hackernews?: string;
+  bluesky?: string;
 };
 
 export type PostComplete = Post & {
@@ -54,7 +58,7 @@ export async function getAllPosts(): Promise<Post[]> {
     const slug = file.replace(/\.md$/, "");
     const raw = await fs.readFile(path.join(postsDir, file), "utf8");
     const { data } = matter(raw);
-    const { title, date: frontmatterDate, draft, summary, tags, ogImage } = Front.parse(data);
+    const { title, date: frontmatterDate, draft, summary, tags, ogImage, hackernews, bluesky } = Front.parse(data);
     const date = frontmatterDate ?? getDateFromSlug(slug);
     posts.push({
       title,
@@ -64,6 +68,8 @@ export async function getAllPosts(): Promise<Post[]> {
       slug,
       tags,
       ogImage,
+      hackernews,
+      bluesky,
     });
   }
 
@@ -76,7 +82,7 @@ export async function getAllPosts(): Promise<Post[]> {
 export async function getPost(slug: string): Promise<PostComplete> {
   const raw = await fs.readFile(path.join(postsDir, `${slug}.md`), "utf8");
   const { data, content } = matter(raw);
-  const { title, date: frontmatterDate, draft, summary, tags, ogImage } = Front.parse(data);
+  const { title, date: frontmatterDate, draft, summary, tags, ogImage, hackernews, bluesky } = Front.parse(data);
   const date = frontmatterDate ?? getDateFromSlug(slug);
 
   // Build the current post
@@ -88,6 +94,8 @@ export async function getPost(slug: string): Promise<PostComplete> {
     slug,
     tags,
     ogImage,
+    hackernews,
+    bluesky,
     content,
   };
 


### PR DESCRIPTION
## Summary
This PR adds support for linking to discussion threads on Hacker News and Bluesky from blog posts. Users can now optionally specify discussion URLs in post frontmatter, which will be displayed as a "Discuss this post on..." section in the comments area.

## Key Changes
- **New Component**: Created `DiscussLinks` component that renders discussion links with proper formatting (joins multiple links with "or")
- **Post Metadata**: Extended post frontmatter schema to accept optional `hackernews` and `bluesky` URL fields with URL validation
- **Post Type Updates**: Added `hackernews` and `bluesky` optional fields to `Post` and `PostComplete` types
- **Data Flow**: Updated `getAllPosts()` and `getPost()` functions to parse and include the new discussion fields
- **UI Integration**: Modified `Comments` component to accept and display discussion links via the new `DiscussLinks` component
- **Page Integration**: Updated post page to pass discussion URLs from post data to the Comments component

## Implementation Details
- The `DiscussLinks` component returns `null` if neither URL is provided, avoiding unnecessary rendering
- Links are joined with " or " separator when multiple discussion platforms are available
- URLs are validated at the schema level using Zod's `.url()` validator
- The component uses semantic HTML with proper accessibility (underlined links)

https://claude.ai/code/session_01Nq3KBggLbAgqzZ6uP2wgR7