### PR TITLE
Add RSS feed metadata and improve feed link accessibility

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,6 +26,11 @@ export const metadata: Metadata = {
     title: site.name,
     description: site.description,
   },
+  alternates: {
+    types: {
+      "application/rss+xml": [{ url: "/feed.xml", title: site.name }],
+    },
+  },
 };
 
 

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -37,7 +37,7 @@ export default function SocialLinks() {
       <a href="https://bsky.app/profile/skagedal.tech">
         <SiBluesky />
       </a>
-      <a href="/feed.xml">
+      <a href="/feed.xml" aria-label="RSS feed" title="RSS feed">
         <RssIcon />
       </a>
     </nav>


### PR DESCRIPTION
## Summary
This PR improves RSS feed discoverability and accessibility by adding proper metadata to the site layout and enhancing the feed link with accessibility attributes.

## Key Changes
- **Added RSS feed metadata**: Included `alternates` configuration in the site metadata to declare the RSS feed URL (`/feed.xml`) with proper content type (`application/rss+xml`). This allows browsers and feed readers to automatically discover the feed.
- **Improved RSS link accessibility**: Added `aria-label` and `title` attributes to the RSS feed link in the footer for better accessibility and user experience.

## Implementation Details
- The metadata change follows the Next.js metadata API conventions for declaring alternate content types
- The accessibility attributes provide both screen reader support and tooltip information for the RSS feed link

https://claude.ai/code/session_01SLF22HqFRkR64AjwvoAKq2