### PR TITLE
Add LinkedIn to social discuss links

### DIFF
--- a/content/posts/2026-05-01-cloudwatch-insights-tool.md
+++ b/content/posts/2026-05-01-cloudwatch-insights-tool.md
@@ -4,6 +4,7 @@ title: "Small tools, shared with agents: a CloudWatch Insights example"
 date: 2026-05-01
 bluesky: "https://bsky.app/profile/skagedal.tech/post/3mkrwhicma22d"
 hackernews: "https://news.ycombinator.com/item?id=47973166"
+linkedin: "https://www.linkedin.com/posts/skagedal_en-liten-bloggpost-om-ett-litet-logverktyg-share-7455935992475082752-EWRR"
 summary: "On building small CLI tools for myself – and now for my agents too. Walks through a recent one for querying CloudWatch Insights, and how I use Claude to analyze the logs it pulls down."
 ---
 

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -102,6 +102,7 @@ export default async function PostPage({
               pageId={slug}
               hackernews={post.hackernews}
               bluesky={post.bluesky}
+              linkedin={post.linkedin}
             />
           )}
         </article>

--- a/src/components/comments/comments.tsx
+++ b/src/components/comments/comments.tsx
@@ -11,9 +11,10 @@ type Props = {
   pageId: string;
   hackernews?: string;
   bluesky?: string;
+  linkedin?: string;
 }
 
-export async function Comments({ pageId, hackernews, bluesky }: Props) {
+export async function Comments({ pageId, hackernews, bluesky, linkedin }: Props) {
   const user = await getUser();
   console.log('User:', user);
 
@@ -23,7 +24,7 @@ export async function Comments({ pageId, hackernews, bluesky }: Props) {
         <MessageSquare className="mr-2 h-5 w-5" />
         Comments
       </h2>
-      <DiscussLinks hackernews={hackernews} bluesky={bluesky} />
+      <DiscussLinks hackernews={hackernews} bluesky={bluesky} linkedin={linkedin} />
       <ClientContext>
         <FormOrLogin pageId={pageId} user={user} />
         <CommentsList pageId={pageId} />

--- a/src/components/comments/discuss-links.tsx
+++ b/src/components/comments/discuss-links.tsx
@@ -3,10 +3,11 @@ import { Anchor } from "@/components/ui/typography";
 type Props = {
   hackernews?: string;
   bluesky?: string;
+  linkedin?: string;
 };
 
-export function DiscussLinks({ hackernews, bluesky }: Props) {
-  if (!hackernews && !bluesky) {
+export function DiscussLinks({ hackernews, bluesky, linkedin }: Props) {
+  if (!hackernews && !bluesky && !linkedin) {
     return null;
   }
 
@@ -22,6 +23,13 @@ export function DiscussLinks({ hackernews, bluesky }: Props) {
     links.push(
       <Anchor key="bsky" href={bluesky}>
         Blue Sky
+      </Anchor>
+    );
+  }
+  if (linkedin) {
+    links.push(
+      <Anchor key="li" href={linkedin}>
+        LinkedIn
       </Anchor>
     );
   }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -15,6 +15,7 @@ const Front = z.object({
   ogImage: z.string().optional(),
   hackernews: z.string().url().optional(),
   bluesky: z.string().url().optional(),
+  linkedin: z.string().url().optional(),
 });
 
 export type Post = {
@@ -27,6 +28,7 @@ export type Post = {
   ogImage?: string;
   hackernews?: string;
   bluesky?: string;
+  linkedin?: string;
 };
 
 export type PostComplete = Post & {
@@ -58,7 +60,7 @@ export async function getAllPosts(): Promise<Post[]> {
     const slug = file.replace(/\.md$/, "");
     const raw = await fs.readFile(path.join(postsDir, file), "utf8");
     const { data } = matter(raw);
-    const { title, date: frontmatterDate, draft, summary, tags, ogImage, hackernews, bluesky } = Front.parse(data);
+    const { title, date: frontmatterDate, draft, summary, tags, ogImage, hackernews, bluesky, linkedin } = Front.parse(data);
     const date = frontmatterDate ?? getDateFromSlug(slug);
     posts.push({
       title,
@@ -70,6 +72,7 @@ export async function getAllPosts(): Promise<Post[]> {
       ogImage,
       hackernews,
       bluesky,
+      linkedin,
     });
   }
 
@@ -82,7 +85,7 @@ export async function getAllPosts(): Promise<Post[]> {
 export async function getPost(slug: string): Promise<PostComplete> {
   const raw = await fs.readFile(path.join(postsDir, `${slug}.md`), "utf8");
   const { data, content } = matter(raw);
-  const { title, date: frontmatterDate, draft, summary, tags, ogImage, hackernews, bluesky } = Front.parse(data);
+  const { title, date: frontmatterDate, draft, summary, tags, ogImage, hackernews, bluesky, linkedin } = Front.parse(data);
   const date = frontmatterDate ?? getDateFromSlug(slug);
 
   // Build the current post
@@ -96,6 +99,7 @@ export async function getPost(slug: string): Promise<PostComplete> {
     ogImage,
     hackernews,
     bluesky,
+    linkedin,
     content,
   };
 


### PR DESCRIPTION
Adds linkedin frontmatter field for posts and renders it alongside
Hacker News and Blue Sky in the discuss links. Adds the LinkedIn URL
to the CloudWatch Insights post.