### PR TITLE
Improve discussion links formatting and copy

### DIFF
--- a/src/components/comments/discuss-links.tsx
+++ b/src/components/comments/discuss-links.tsx
@@ -29,20 +29,23 @@ export function DiscussLinks({ hackernews, bluesky, linkedin }: Props) {
   if (linkedin) {
     links.push(
       <Anchor key="li" href={linkedin}>
-        LinkedIn
+        Linked In
       </Anchor>
     );
   }
 
   const joined: React.ReactNode[] = [];
   links.forEach((link, i) => {
-    if (i > 0) joined.push(<span key={`sep-${i}`}> or </span>);
+    if (i > 0) {
+      const sep = i === links.length - 1 ? " or " : ", ";
+      joined.push(<span key={`sep-${i}`}>{sep}</span>);
+    }
     joined.push(link);
   });
 
   return (
     <p className="mb-6 text-muted-foreground">
-      Or discuss this post on {joined}.
+      Discuss this post on {joined}.
     </p>
   );
 }


### PR DESCRIPTION
## Summary
Updated the discussion links component to improve readability and user experience with better formatting and clearer messaging.

## Key Changes
- **Separator logic**: Changed from always using " or " to using commas between multiple links and " or " only before the final link (e.g., "HackerNews, Bluesky or LinkedIn")
- **Copy improvement**: Removed "Or" from the beginning of the sentence for more natural phrasing ("Discuss this post on..." instead of "Or discuss this post on...")
- **Branding fix**: Corrected "LinkedIn" spacing to "Linked In" for proper brand name formatting

## Implementation Details
- The separator selection now checks if the current link is the last one (`i === links.length - 1`) to determine whether to use a comma or " or "
- This creates a more natural reading experience when multiple discussion platforms are available

https://claude.ai/code/session_01PG34UKK9YpzgWYrNkBxCcU