### PR TITLE
Add email + password sign-in

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,29 @@
+import { redirect } from "next/navigation";
+import { headers } from "next/headers";
+import { auth } from "@/auth";
+import { LoginForm } from "@/components/auth/login-form";
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = Promise<{ next?: string }>;
+
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  const { next } = await searchParams;
+  const safeNext = next && next.startsWith("/") ? next : "/";
+
+  if (session) {
+    redirect(safeNext);
+  }
+
+  return (
+    <main className="mx-auto max-w-md flex-1 p-4">
+      <h1 className="text-3xl font-bold mb-8">Sign in</h1>
+      <LoginForm next={safeNext} />
+    </main>
+  );
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -20,6 +20,10 @@ export const auth = betterAuth({
           },
         }
       : {},
+  emailAndPassword: {
+    enabled: true,
+    minPasswordLength: 12,
+  },
   databaseHooks: {
     user: {
       create: {

--- a/src/components/admin/admin-login.tsx
+++ b/src/components/admin/admin-login.tsx
@@ -1,10 +1,8 @@
-"use client";
-
 import { Shield } from "lucide-react";
+import Link from "next/link";
 import { Alert, AlertDescription } from "../ui/alert";
 import { Card, CardContent, CardFooter } from "../ui/card";
 import { Button } from "../ui/button";
-import { authClient } from "@/lib/auth-client";
 
 export function AdminLogin() {
   return (
@@ -13,13 +11,13 @@ export function AdminLogin() {
         <Alert>
           <Shield className="h-4 w-4" />
           <AlertDescription>
-            Please log in to access the admin panel. You need administrator privileges to view this page.
+            Please sign in to access the admin panel. You need administrator privileges to view this page.
           </AlertDescription>
         </Alert>
       </CardContent>
       <CardFooter className="flex justify-end px-6 pb-6 pt-0">
-        <Button onClick={() => authClient.signIn.social({ provider: "google", callbackURL: "/admin" })}>
-          Log in with Google
+        <Button asChild>
+          <Link href="/login?next=/admin">Sign in</Link>
         </Button>
       </CardFooter>
     </Card>

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import { authClient } from "@/lib/auth-client";
+import { Loader2 } from "lucide-react";
+
+const MIN_PASSWORD = 12;
+
+type Mode = "sign-in" | "sign-up";
+
+export function LoginForm({ next }: { next: string }) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [mode, setMode] = useState<Mode>("sign-in");
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      if (mode === "sign-in") {
+        const { error } = await authClient.signIn.email({ email, password });
+        if (error) throw new Error(error.message ?? "Sign in failed");
+      } else {
+        const { error } = await authClient.signUp.email({
+          email,
+          password,
+          name: name.trim(),
+        });
+        if (error) throw new Error(error.message ?? "Sign up failed");
+      }
+      router.push(next);
+      router.refresh();
+    } catch (err) {
+      toast({
+        title: mode === "sign-in" ? "Sign in failed" : "Sign up failed",
+        description: err instanceof Error ? err.message : "Please try again.",
+        variant: "destructive",
+      });
+      setSubmitting(false);
+    }
+  };
+
+  const onGoogle = async () => {
+    setSubmitting(true);
+    await authClient.signIn.social({ provider: "google", callbackURL: next });
+  };
+
+  const isSignUp = mode === "sign-up";
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex gap-2 text-sm">
+          <button
+            type="button"
+            onClick={() => setMode("sign-in")}
+            className={`px-3 py-1 rounded-md ${mode === "sign-in" ? "bg-accent text-accent-foreground" : "text-muted-foreground"}`}
+          >
+            Sign in
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode("sign-up")}
+            className={`px-3 py-1 rounded-md ${mode === "sign-up" ? "bg-accent text-accent-foreground" : "text-muted-foreground"}`}
+          >
+            Create account
+          </button>
+        </div>
+      </CardHeader>
+      <form onSubmit={onSubmit}>
+        <CardContent className="space-y-4">
+          {isSignUp && (
+            <div className="space-y-1">
+              <label htmlFor="name" className="text-sm font-medium">Name</label>
+              <input
+                id="name"
+                type="text"
+                required
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoComplete="name"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+          )}
+          <div className="space-y-1">
+            <label htmlFor="email" className="text-sm font-medium">Email</label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              autoComplete="email"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="password" className="text-sm font-medium">Password</label>
+            <input
+              id="password"
+              type="password"
+              required
+              minLength={isSignUp ? MIN_PASSWORD : undefined}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete={isSignUp ? "new-password" : "current-password"}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+            {isSignUp && (
+              <p className="text-xs text-muted-foreground">
+                At least {MIN_PASSWORD} characters.
+              </p>
+            )}
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-3">
+          <Button type="submit" disabled={submitting} className="w-full">
+            {submitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {isSignUp ? "Creating account" : "Signing in"}
+              </>
+            ) : isSignUp ? (
+              "Create account"
+            ) : (
+              "Sign in"
+            )}
+          </Button>
+          <div className="flex items-center gap-3 w-full text-xs text-muted-foreground">
+            <div className="flex-1 border-t" />
+            <span>or</span>
+            <div className="flex-1 border-t" />
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={submitting}
+            onClick={onGoogle}
+            className="w-full"
+          >
+            Continue with Google
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}

--- a/src/components/comments/not-logged-in.tsx
+++ b/src/components/comments/not-logged-in.tsx
@@ -1,28 +1,29 @@
 "use client";
 
 import { MessageSquare } from "lucide-react";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
 import { Alert, AlertDescription } from "../ui/alert";
 import { Card, CardContent, CardFooter } from "../ui/card";
 import { Button } from "../ui/button";
-import { authClient } from "@/lib/auth-client";
 
 export function NotLoggedIn() {
+  const pathname = usePathname();
+  const href = `/login?next=${encodeURIComponent(pathname)}`;
   return (
     <Card className="mb-8">
       <CardContent className="p-6">
         <Alert>
           <MessageSquare className="h-4 w-4" />
           <AlertDescription>
-            Please log in to leave a comment. Currently, only Google login is
-            supported. If this is a problem for you, and you would like to
-            comment on the blog, please contact me through any of the means
-            listed at the site footer.
+            Please sign in to leave a comment. You can sign in with Google or
+            with an email address and password.
           </AlertDescription>
         </Alert>
       </CardContent>
       <CardFooter className="flex justify-end px-6 pb-6 pt-0">
-        <Button onClick={() => authClient.signIn.social({ provider: "google", callbackURL: window.location.pathname })}>
-          Log in with Google
+        <Button asChild>
+          <Link href={href}>Sign in</Link>
         </Button>
       </CardFooter>
     </Card>


### PR DESCRIPTION
## Summary
Second of three Better Auth PRs. Builds on #25.

- Enables Better Auth's email/password provider (12-char minimum) in `src/auth.ts`.
- Adds `/login` page with both sign-in and sign-up forms (toggle), plus a "Continue with Google" button below the divider.
- The "please log in" cards on comment threads and `/admin` now link to `/login?next=<current path>` instead of triggering a Google redirect directly.
- Sign-up creates the user via `authClient.signUp.email`; the existing `databaseHooks.user.create.after` adds the matching `blogdans_user` profile row, falling back to a picsum default photo since email/password sign-ups have no avatar.

Forgot-password is intentionally **not** wired up here — that's PR 3 (Resend + abuse hardening).

## Verification
Locally: `POST /api/auth/sign-up/email` returned 200, the `user`, `account` (`providerId='credential'`), and `blogdans_user` rows all landed correctly, the session cookie was issued, and `/login` / `/login?next=/admin` render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)