### PR TITLE
Upgrade all GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,15 +13,15 @@
           "runs-on": "ubuntu-latest",
           steps:
             [
-              { name: "Check out code", uses: "actions/checkout@v6" },
+              { name: "Check out code", uses: "actions/checkout@v7" },
               {
                 name: "Set up pnpm",
-                uses: "pnpm/action-setup@v5",
+                uses: "pnpm/action-setup@v6",
                 with: { package_json_file: "package.yaml" },
               },
               {
                 name: "Set up Node.js",
-                uses: "actions/setup-node@v6",
+                uses: "actions/setup-node@v7",
                 with: { "node-version": "22", cache: "pnpm" },
               },
               {
@@ -40,14 +40,14 @@
           "runs-on": "ubuntu-latest",
           steps:
             [
-              { name: "Check out code", uses: "actions/checkout@v6" },
+              { name: "Check out code", uses: "actions/checkout@v7" },
               {
                 name: "Set up Docker Buildx",
-                uses: "docker/setup-buildx-action@v3",
+                uses: "docker/setup-buildx-action@v4",
               },
               {
                 name: "Log in to Docker Hub",
-                uses: "docker/login-action@v3",
+                uses: "docker/login-action@v4",
                 with:
                   {
                     username: "${{ secrets.DOCKERHUB_USERNAME }}",
@@ -56,7 +56,7 @@
               },
               {
                 name: "Build and push",
-                uses: "docker/build-push-action@v5",
+                uses: "docker/build-push-action@v7",
                 with:
                   {
                     context: ".",
@@ -65,7 +65,7 @@
                     tags: "skagedal/blogdans:latest",
                   },
               },
-              { name: "Set up kubectl", uses: "azure/setup-kubectl@v4" },
+              { name: "Set up kubectl", uses: "azure/setup-kubectl@v5" },
               {
                 name: "Configure kubeconfig",
                 env:


### PR DESCRIPTION
The deploy job was logging `Node 20 is being deprecated. This workflow is running with Node 24 by default.` on every run ([example](https://github.com/skagedal/blogdans/actions/runs/31797627993)). The warnings came from the four actions in the build-and-deploy job, all of which declared `node20`; their latest majors ship `node24`. While in there, I also bumped checkout, setup-node and pnpm/action-setup, which were each one major behind but not yet warning.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v6 | v7 |
| `pnpm/action-setup` | v5 | v6 |
| `actions/setup-node` | v6 | v7 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v5 | v7 |
| `azure/setup-kubectl` | v4 | v5 |

The release notes for each major were checked; none of the breaking changes affect how we use these actions:

- **build-push-action v7** dropped the `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs — unused here, we only pass `context`, `file`, `push`, `tags`.
- **setup-buildx-action v4** removed deprecated inputs — we pass none.
- **setup-kubectl v5** moved downloads to `dl.k8s.io` and auto-resolves a `major.minor` pin to the latest patch — we pin no version, so it still takes stable.
- **pnpm/action-setup v6** adds pnpm 11 support and keeps `package_json_file`, so the `package.yaml` workaround stays intact.

These majors require Actions Runner >= 2.327.1, which `ubuntu-latest` on github.com is well past.

The remaining `DEP0169 url.parse()` and `DEP0040 punycode` warnings in the logs come from inside the actions' own dependencies, not from our config, so they are unaffected by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqFEtzLjZPbm1GQivkk9xk
